### PR TITLE
Align initialization order

### DIFF
--- a/hueplusplus/Hue.cpp
+++ b/hueplusplus/Hue.cpp
@@ -124,15 +124,15 @@ std::string HueFinder::ParseDescription(const std::string & description)
 
 Hue::Hue(const std::string &ip, const std::string &username,
          std::shared_ptr<const IHttpHandler> handler)
-    : ip(ip), username(username), http_handler(std::move(handler)),
-      commands(ip, username, http_handler),
+    : ip(ip), username(username),
       simpleBrightnessStrategy(std::make_shared<SimpleBrightnessStrategy>()),
       simpleColorHueStrategy(std::make_shared<SimpleColorHueStrategy>()),
       extendedColorHueStrategy(std::make_shared<ExtendedColorHueStrategy>()),
       simpleColorTemperatureStrategy(
           std::make_shared<SimpleColorTemperatureStrategy>()),
       extendedColorTemperatureStrategy(
-          std::make_shared<ExtendedColorTemperatureStrategy>()) {}
+          std::make_shared<ExtendedColorTemperatureStrategy>()),
+      http_handler(std::move(handler)), commands(ip, username, http_handler) {}
 
 std::string Hue::getBridgeIP() { return ip; }
 


### PR DESCRIPTION
Align the constructors initialization order with the order of definitions
in Hue.h

I ran into a simple build error trying to port this library to the ESP32 Platform.
This fixes the error, though technically my fix was originally applied to master, I assume development is the right branch for this to land?

```In file included from /Users/sierenmusic/Development/HomeControl/main/libraries/hueplusplus/hueplusplus/Hue.cpp:20:
/Users/sierenmusic/Development/HomeControl/main/libraries/hueplusplus/hueplusplus/include/Hue.h: In constructor 'Hue::Hue(const string&, const string&, std::shared_ptr<const IHttpHandler>)':
/Users/sierenmusic/Development/HomeControl/main/libraries/hueplusplus/hueplusplus/include/Hue.h:202:41: error: 'Hue::http_handler' will be initialized after [-Werror=reorder]
     std::shared_ptr<const IHttpHandler> http_handler;                               //!< A IHttpHandler that is used to communicate with the bridge
                                         ^~~~~~~~~~~~
/Users/sierenmusic/Development/HomeControl/main/libraries/hueplusplus/hueplusplus/include/Hue.h:197:49: error:   'std::shared_ptr<BrightnessStrategy> Hue::simpleBrightnessStrategy' [-Werror=reorder]
     std::shared_ptr<BrightnessStrategy>         simpleBrightnessStrategy;           //!< Strategy that is used for controlling the brightness of lights
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/sierenmusic/Development/HomeControl/main/libraries/hueplusplus/hueplusplus/Hue.cpp:105:1: error:   when initialized here [-Werror=reorder]
 Hue::Hue(const std::string& ip, const std::string& username, std::shared_ptr<const IHttpHandler> handler)
 ^~~```