### PR TITLE
Support Ports other than 80

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     # Misc
     - RUN_TESTS=true
     - COVERAGE=false
+    - PATH=${DEPS_DIR}/cmake/bin:${PATH}
 
 matrix:
   include:
@@ -42,7 +43,7 @@ install:
     - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-5 90
     # Download and install recent cmake
     - if [[ ${TRAVIS_OS_NAME} == "linux" ]]; then
-        CMAKE_URL="http://www.cmake.org/files/v3.5/cmake-3.5.1-Linux-x86_64.tar.gz";
+        CMAKE_URL="https://cmake.org/files/v3.7/cmake-3.7.0-Linux-x86_64.tar.gz";
         mkdir -p ${DEPS_DIR}/cmake;
         travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${DEPS_DIR}/cmake;
         export PATH=${DEPS_DIR}/cmake/bin:${PATH};
@@ -54,6 +55,7 @@ install:
     - echo ${CXX}
     - ${CXX} --version
     - ${CXX} -v
+    - cmake --version
     - lcov --version
 
 script:

--- a/hueplusplus/HueCommandAPI.cpp
+++ b/hueplusplus/HueCommandAPI.cpp
@@ -23,9 +23,10 @@
 
 constexpr std::chrono::steady_clock::duration HueCommandAPI::minDelay;
 
-HueCommandAPI::HueCommandAPI(const std::string &ip, const std::string &username,
+HueCommandAPI::HueCommandAPI(const std::string &ip, const int port,
+                             const std::string &username,
                              std::shared_ptr<const IHttpHandler> httpHandler)
-    : ip(ip), username(username), httpHandler(std::move(httpHandler)),
+    : ip(ip), port(port), username(username), httpHandler(std::move(httpHandler)),
       timeout(new TimeoutData{std::chrono::steady_clock::now()}) {}
 
 Json::Value HueCommandAPI::PUTRequest(const std::string &path,
@@ -40,7 +41,7 @@ Json::Value HueCommandAPI::PUTRequest(const std::string &path,
       "/api/" + username + (path.empty() || path.front() == '/' ? "" : "/") +
       path;
   try {
-    Json::Value v = httpHandler->PUTJson(combinedPath, request, ip);
+    Json::Value v = httpHandler->PUTJson(combinedPath, request, ip, port);
     timeout->timeout = now + minDelay;
     return v;
   } catch (const std::system_error &e) {
@@ -69,7 +70,7 @@ Json::Value HueCommandAPI::GETRequest(const std::string &path,
       "/api/" + username + (path.empty() || path.front() == '/' ? "" : "/") +
       path;
   try {
-    Json::Value v = httpHandler->GETJson(combinedPath, request, ip);
+    Json::Value v = httpHandler->GETJson(combinedPath, request, ip, port);
     timeout->timeout = now + minDelay;
     return v;
   } catch (const std::system_error &e) {
@@ -77,7 +78,7 @@ Json::Value HueCommandAPI::GETRequest(const std::string &path,
         e.code() == std::errc::timed_out) {
       // Happens when hue is too busy, wait and try again (once)
       std::this_thread::sleep_for(minDelay);
-      Json::Value v = httpHandler->GETJson(combinedPath, request, ip);
+      Json::Value v = httpHandler->GETJson(combinedPath, request, ip, port);
       timeout->timeout = std::chrono::steady_clock::now() + minDelay;
       return v;
     }
@@ -98,7 +99,7 @@ Json::Value HueCommandAPI::DELETERequest(const std::string &path,
       "/api/" + username + (path.empty() || path.front() == '/' ? "" : "/") +
       path;
   try {
-    Json::Value v = httpHandler->DELETEJson(combinedPath, request, ip);
+    Json::Value v = httpHandler->DELETEJson(combinedPath, request, ip, port);
     timeout->timeout = now + minDelay;
     return v;
   } catch (const std::system_error &e) {
@@ -106,7 +107,7 @@ Json::Value HueCommandAPI::DELETERequest(const std::string &path,
         e.code() == std::errc::timed_out) {
       // Happens when hue is too busy, wait and try again (once)
       std::this_thread::sleep_for(minDelay);
-      Json::Value v = httpHandler->DELETEJson(combinedPath, request, ip);
+      Json::Value v = httpHandler->DELETEJson(combinedPath, request, ip, port);
       timeout->timeout = std::chrono::steady_clock::now() + minDelay;
       return v;
     }

--- a/hueplusplus/include/Hue.h
+++ b/hueplusplus/include/Hue.h
@@ -45,6 +45,7 @@ class HueFinder {
 public:
   struct HueIdentification {
     std::string ip;
+    int port = 80;
     std::string mac;
   };
 
@@ -107,17 +108,22 @@ public:
   //! \brief Constructor of Hue class
   //!
   //! \param ip String that specifies the ip address of the Hue bridge in dotted
-  //! decimal notation like "192.168.2.1" \param username String that specifies
-  //! the username that is used to control the bridge. This needs to be acquired
-  //! in \ref requestUsername \param handler HttpHandler of type \ref
-  //! IHttpHandler for communication with the bridge
-  Hue(const std::string &ip, const std::string &username,
-      std::shared_ptr<const IHttpHandler> handler);
+  //! decimal notation like "192.168.2.1" \param port Port of the hue bridge
+  //! \param username String that specifies the username that is used to control
+  //! the bridge. This needs to be acquired in \ref requestUsername \param handler
+  //!  HttpHandler of type \ref IHttpHandler for communication with the bridge
+  Hue(const std::string &ip, const int port, const std::string &username,
+        std::shared_ptr<const IHttpHandler> handler);
 
   //! \brief Function to get the ip address of the hue bridge
   //!
   //! \return string containing ip
   std::string getBridgeIP();
+
+  //! \brief Function to get the port of the hue bridge
+  //!
+  //! \return integer containing port
+  int getBridgePort();
 
   //! \brief Function that sends a username request to the Hue bridge.
   //!
@@ -140,6 +146,12 @@ public:
   //! \param ip String that specifies the ip in dotted decimal notation like
   //! "192.168.2.1"
   void setIP(const std::string &ip);
+
+  //! \brief Function to set the port of this class representing a bridge
+  //!
+  //! \param port Integer that specifies the port of an address like
+  //! "192.168.2.1:8080"
+  void setPort(const int port);
 
   //! \brief Function that returns a \ref Hue::HueLight of specified id
   //!
@@ -209,7 +221,7 @@ public:
   //! \param handler a HttpHandler of type \ref IHttpHandler
   void setHttpHandler(std::shared_ptr<const IHttpHandler> handler) {
     http_handler = std::move(handler);
-    commands = HueCommandAPI(ip, username, http_handler);
+    commands = HueCommandAPI(ip, port, username, http_handler);
   };
 
 private:
@@ -219,6 +231,7 @@ private:
 private:
   std::string ip; //!< IP-Address of the hue bridge in dotted decimal notation
                   //!< like "192.168.2.1"
+  int port;
   std::string username; //!< Username that is ussed to access the hue bridge
   Json::Value state; //!< The state of the hue bridge as it is returned from it
   std::map<uint8_t, HueLight>

--- a/hueplusplus/include/HueCommandAPI.h
+++ b/hueplusplus/include/HueCommandAPI.h
@@ -33,10 +33,11 @@ public:
   //! \brief Construct from ip, username and HttpHandler
   //!
   //! \param ip String that specifies the ip address of the Hue bridge in dotted
-  //! decimal notation like "192.168.2.1" \param username String that specifies
-  //! the username that is used to control the bridge \param handler HttpHandler
-  //! of type \ref IHttpHandler for communication with the bridge
-  HueCommandAPI(const std::string &ip, const std::string &username,
+  //! decimal notation like "192.168.2.1" \param port of the hue bridge
+  //! \param username String that specifies the username that is used to control
+  //! the bridge \param handler HttpHandler of type \ref IHttpHandler for
+  //! communication with the bridge
+  HueCommandAPI(const std::string &ip, const int port, const std::string &username,
                 std::shared_ptr<const IHttpHandler> httpHandler);
 
   //! \brief Copy construct from other HueCommandAPI
@@ -100,6 +101,7 @@ private:
   static constexpr std::chrono::steady_clock::duration minDelay =
       std::chrono::milliseconds(100);
   std::string ip;
+  int port;
   std::string username;
   std::shared_ptr<const IHttpHandler> httpHandler;
   std::shared_ptr<TimeoutData> timeout;

--- a/hueplusplus/test/CMakeLists.txt
+++ b/hueplusplus/test/CMakeLists.txt
@@ -54,6 +54,8 @@ target_include_directories(test_HuePlusPlus PUBLIC ${GTest_INCLUDE_DIRS})
 target_include_directories(test_HuePlusPlus PUBLIC ${HuePlusPlus_INCLUDE_DIR})
 set_property(TARGET test_HuePlusPlus PROPERTY CXX_STANDARD 14)
 set_property(TARGET test_HuePlusPlus PROPERTY CXX_EXTENSIONS OFF)
+set_property(TARGET gmock PROPERTY CXX_STANDARD 14)
+set_property(TARGET gtest PROPERTY CXX_STANDARD 14)
 # add custom target to make it simple to run the tests
 add_custom_target("unittest"
     # Run the executable

--- a/hueplusplus/test/mocks/mock_HueLight.h
+++ b/hueplusplus/test/mocks/mock_HueLight.h
@@ -33,7 +33,9 @@
 class MockHueLight : public HueLight
 {
 public:
-    MockHueLight(std::shared_ptr<const IHttpHandler> handler) : HueLight(1, HueCommandAPI(getBridgeIp(), getBridgeUsername(), handler)) {};
+    MockHueLight(std::shared_ptr<const IHttpHandler> handler) : HueLight(1,
+        HueCommandAPI(getBridgeIp(), getBridgePort(), getBridgeUsername(),
+        handler)) {};
 
     Json::Value& getState() { return state; };
 

--- a/hueplusplus/test/test_HueCommandAPI.cpp
+++ b/hueplusplus/test/test_HueCommandAPI.cpp
@@ -30,7 +30,8 @@ TEST(HueCommandAPI, PUTRequest) {
   std::shared_ptr<MockHttpHandler> httpHandler =
       std::make_shared<MockHttpHandler>();
 
-  HueCommandAPI api(getBridgeIp(), getBridgeUsername(), httpHandler);
+  HueCommandAPI api(getBridgeIp(), getBridgePort(), getBridgeUsername(),
+      httpHandler);
   Json::Value request;
   Json::Value result = Json::objectValue;
   result["ok"] = true;
@@ -102,7 +103,8 @@ TEST(HueCommandAPI, GETRequest) {
   std::shared_ptr<MockHttpHandler> httpHandler =
       std::make_shared<MockHttpHandler>();
 
-  HueCommandAPI api(getBridgeIp(), getBridgeUsername(), httpHandler);
+  HueCommandAPI api(getBridgeIp(), getBridgePort(), getBridgeUsername(),
+      httpHandler);
   Json::Value request;
   Json::Value result = Json::objectValue;
   result["ok"] = true;
@@ -174,7 +176,8 @@ TEST(HueCommandAPI, DELETERequest) {
   std::shared_ptr<MockHttpHandler> httpHandler =
       std::make_shared<MockHttpHandler>();
 
-  HueCommandAPI api(getBridgeIp(), getBridgeUsername(), httpHandler);
+  HueCommandAPI api(getBridgeIp(), getBridgePort(), getBridgeUsername(),
+      httpHandler);
   Json::Value request;
   Json::Value result = Json::objectValue;
   result["ok"] = true;

--- a/hueplusplus/test/test_HueLight.cpp
+++ b/hueplusplus/test/test_HueLight.cpp
@@ -16,7 +16,8 @@ protected:
 protected:
   HueLightTest()
       : handler(std::make_shared<MockHttpHandler>()),
-        test_bridge(getBridgeIp(), getBridgeUsername(), handler) {
+        test_bridge(getBridgeIp(), getBridgePort(), getBridgeUsername(),
+            handler) {
     using namespace ::testing;
     hue_bridge_state["lights"] = Json::Value(Json::objectValue);
     hue_bridge_state["lights"]["1"] = Json::Value(Json::objectValue);

--- a/hueplusplus/test/testhelper.h
+++ b/hueplusplus/test/testhelper.h
@@ -6,6 +6,10 @@ inline std::string getBridgeIp() {
                           //!< decimal notation like "192.168.2.1"
 }
 
+inline int getBridgePort() {
+  return 80;
+}
+
 inline std::string getBridgeUsername() {
   return "83b7780291a6ceffbe0bd049104df"; //!< Username that is ussed to access
                                           //!< the fake hue bridge


### PR DESCRIPTION
Occasionally Hue-protocol emulating systems like DeCONZ,
Phoscon / ConBee can run on ports other than 80.
Especially if running on a local raspberry pi server,
a user might run this on a different port than 80.

Additionally fixed an issue compiling Google Test on MacOS
and bumped the Cmake version as GoogleTest now requires v3.7.

(See: https://github.com/dresden-elektronik/deconz-rest-plugin/wiki/Hue-API-Compatibility )