### PR TITLE
Add Support for ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A simple and easy to use library for Philips Hue Lights
 * Linux
 * Windows
 * MacOS
+* Espressif ESP32 SDK & Arduino
 
 ## How to use
 ### <a name="searchingBridges"></a>Searching for Bridges

--- a/hueplusplus/CMakeLists.txt
+++ b/hueplusplus/CMakeLists.txt
@@ -26,6 +26,12 @@ if(UNIX)
         ${CMAKE_CURRENT_SOURCE_DIR}/LinHttpHandler.cpp
     )
 endif()
+if(ESP_PLATFORM)
+    set(hueplusplus_SOURCES
+        ${hueplusplus_SOURCES}
+       ${CMAKE_CURRENT_SOURCE_DIR}/LinHttpHandler.cpp
+    )
+endif()
 
 
 # Set global includes BEFORE adding any targets for legacy CMake versions


### PR DESCRIPTION
ESP32 is using Lwip inside their ESP-IDF SDK (which also
backs the Arduino SDK for ESP32). Lwip has a similar, if not
same API as the Linux TCP/IP stack, therefore no additional
changes other than Cmake-support needed to be made.

Would be nice to have this upstream as I'm looking into adding Hue Support to https://github.com/sieren/Homepoint :) 