### PR TITLE
Add sensor support

### DIFF
--- a/include/hueplusplus/Hue.h
+++ b/include/hueplusplus/Hue.h
@@ -34,6 +34,7 @@
 #include "ColorTemperatureStrategy.h"
 #include "HueCommandAPI.h"
 #include "HueLight.h"
+#include "HueSensor.h"
 #include "IHttpHandler.h"
 
 #include "json/json.hpp"
@@ -173,6 +174,16 @@ public:
     //! \throws nlohmann::json::parse_error when response could not be parsed
     HueLight& getLight(int id);
 
+    //! \brief Function that returns a \ref HueSensor of specified id
+    //!
+    //! \param id Integer that specifies the ID of a Hue sensor
+    //! \return \ref HueSensor that can be controlled
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when id does not exist or type is unknown
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    HueSensor& getSensor(int id);
+
     //! \brief Function to remove a light from the bridge
     //!
     //! \attention Any use of the light after it was successfully removed results in undefined behavior
@@ -198,6 +209,16 @@ public:
     //! \throws HueAPIResponseException when response contains an error
     //! \throws nlohmann::json::parse_error when response could not be parsed
     std::vector<std::reference_wrapper<HueLight>> getAllLights();
+
+    //! \brief Function that returns all sensors that are associated with this
+    //! bridge
+    //!
+    //! \return A vector containing references to every HueSensor
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contains no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    std::vector<std::reference_wrapper<HueSensor>> getAllSensors();
 
     //! \brief Function that tells whether a given light id represents an existing light
     //!
@@ -263,6 +284,7 @@ private:
     int port;
     nlohmann::json state; //!< The state of the hue bridge as it is returned from it
     std::map<uint8_t, HueLight> lights; //!< Maps ids to HueLights that are controlled by this bridge
+    std::map<uint8_t, HueSensor> sensors; //!< Maps ids to HueSensors that are controlled by this bridge
 
     std::shared_ptr<BrightnessStrategy> simpleBrightnessStrategy; //!< Strategy that is used for controlling the
                                                                   //!< brightness of lights

--- a/include/hueplusplus/HueLight.h
+++ b/include/hueplusplus/HueLight.h
@@ -29,6 +29,7 @@
 #include "ColorHueStrategy.h"
 #include "ColorTemperatureStrategy.h"
 #include "HueCommandAPI.h"
+#include "HueThing.h"
 
 #include "json/json.hpp"
 
@@ -93,7 +94,7 @@ enum ColorType
 //!
 //! Class for Hue Light fixtures
 //!
-class HueLight
+class HueLight : public HueThing
 {
     friend class Hue;
     friend struct MakeHueLight;
@@ -142,83 +143,11 @@ public:
     //! \return Bool that is true, when the light is on and false, when off
     virtual bool isOn() const;
 
-    //! \brief Const function that returns the id of this light
-    //!
-    //! \return integer representing the light id
-    virtual int getId() const;
-
-    //! \brief Const function that returns the light type
-    //!
-    //! \return String containing the type
-    virtual std::string getType() const;
-
-    //! \brief Function that returns the name of the light.
-    //!
-    //! \return String containig the name of the light
-    //! \throws std::system_error when system or socket operations fail
-    //! \throws HueException when response contained no body
-    //! \throws HueAPIResponseException when response contains an error
-    //! \throws nlohmann::json::parse_error when response could not be parsed
-    virtual std::string getName();
-
-    //! \brief Const function that returns the name of the light.
-    //!
-    //! \note This will not refresh the light state
-    //! \return String containig the name of the light
-    virtual std::string getName() const;
-
-    //! \brief Const function that returns the modelid of the light
-    //!
-    //! \return String conatining the modelid
-    virtual std::string getModelId() const;
-
-    //! \brief Const function that returns the uniqueid of the light
-    //!
-    //! \note Only working on bridges with versions starting at 1.4
-    //! \return String containing the uniqueid or an empty string when the function is not supported
-    virtual std::string getUId() const;
-
-    //! \brief Const function that returns the manufacturername of the light
-    //!
-    //! \note Only working on bridges with versions starting at 1.7
-    //! \return String containing the manufacturername or an empty string when the function is not supported
-    virtual std::string getManufacturername() const;
-
-    //! \brief Const function that returns the productname of the light
-    //!
-    //! \note Only working on bridges with versions starting at 1.24
-    //! \return String containing the productname or an empty string when the function is not supported
-    virtual std::string getProductname() const;
-
     //! \brief Const function that returns the luminaireuniqueid of the light
     //!
     //! \note Only working on bridges with versions starting at 1.9
     //! \return String containing the luminaireuniqueid or an empty string when the function is not supported
     virtual std::string getLuminaireUId() const;
-
-    //! \brief Function that returns the software version of the light
-    //!
-    //! \return String containing the software version
-    //! \throws std::system_error when system or socket operations fail
-    //! \throws HueException when response contained no body
-    //! \throws HueAPIResponseException when response contains an error
-    //! \throws nlohmann::json::parse_error when response could not be parsed
-    virtual std::string getSwVersion();
-
-    //! \brief Const function that returns the software version of the light
-    //!
-    //! \note This will not refresh the light state
-    //! \return String containing the software version
-    virtual std::string getSwVersion() const;
-
-    //! \brief Function that sets the name of the light
-    //!
-    //! \return Bool that is true on success
-    //! \throws std::system_error when system or socket operations fail
-    //! \throws HueException when response contained no body
-    //! \throws HueAPIResponseException when response contains an error
-    //! \throws nlohmann::json::parse_error when response could not be parsed
-    virtual bool setName(const std::string& name);
 
     //! \brief Const function that returns the color type of the light.
     //!
@@ -729,12 +658,6 @@ protected:
         colorHueStrategy = std::move(strat);
     };
 
-    //! \brief Protected function that sets the HueCommandAPI.
-    //!
-    //! The HueCommandAPI is used for bridge communication
-    //! \param commandAPI the new HueCommandAPI
-    virtual void setCommandAPI(const HueCommandAPI& commandAPI) { commands = commandAPI; };
-
     //! \brief Function that turns the light on without refreshing its state.
     //!
     //! \param transition Optional parameter to set the transition from current state to new standard is 4 = 400ms
@@ -755,29 +678,7 @@ protected:
     //! \throws nlohmann::json::parse_error when response could not be parsed
     virtual bool OffNoRefresh(uint8_t transition = 4);
 
-    //! \brief Utility function to send a put request to the light.
-    //!
-    //! \throws nlohmann::json::parse_error if the reply could not be parsed
-    //! \param request A nlohmann::json aka the request to send
-    //! \param subPath A path that is appended to the uri, note it should always start with a slash ("/")
-    //! \param fileInfo FileInfo from calling function for exception details.
-    //! \return The parsed reply
-    //! \throws std::system_error when system or socket operations fail
-    //! \throws HueException when response contained no body
-    //! \throws HueAPIResponseException when response contains an error
-    //! \throws nlohmann::json::parse_error when response could not be parsed
-    virtual nlohmann::json SendPutRequest(const nlohmann::json& request, const std::string& subPath, FileInfo fileInfo);
-
-    //! \brief Virtual function that refreshes the \ref state of the light.
-    //! \throws std::system_error when system or socket operations fail
-    //! \throws HueException when response contained no body
-    //! \throws HueAPIResponseException when response contains an error
-    //! \throws nlohmann::json::parse_error when response could not be parsed
-    virtual void refreshState();
-
 protected:
-    int id; //!< holds the id of the light
-    nlohmann::json state; //!< holds the current state of the light updated by \ref refreshState
     ColorType colorType; //!< holds the \ref ColorType of the light
 
     std::shared_ptr<const BrightnessStrategy>
@@ -786,7 +687,6 @@ protected:
         colorTemperatureStrategy; //!< holds a reference to the strategy that handles colortemperature commands
     std::shared_ptr<const ColorHueStrategy>
         colorHueStrategy; //!< holds a reference to the strategy that handles all color commands
-    HueCommandAPI commands; //!< A IHttpHandler that is used to communicate with the bridge
 };
 } // namespace hueplusplus
 

--- a/include/hueplusplus/HueSensor.h
+++ b/include/hueplusplus/HueSensor.h
@@ -1,0 +1,98 @@
+/**
+    \file HueSensor.h
+    Copyright Notice\n
+    Copyright (C) 2020  Stefan Herbrechtsmeier	- developer\n
+
+    This file is part of hueplusplus.
+
+    hueplusplus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    hueplusplus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with hueplusplus.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef INCLUDE_HUEPLUSPLUS_HUE_SENSOR_H
+#define INCLUDE_HUEPLUSPLUS_HUE_SENSOR_H
+
+#include <memory>
+
+#include "HueCommandAPI.h"
+#include "HueThing.h"
+
+#include "json/json.hpp"
+
+namespace hueplusplus
+{
+//!
+//! Class for Hue Sensor fixtures
+//!
+class HueSensor : public HueThing
+{
+    friend class Hue;
+
+public:
+    //! \brief std dtor
+    ~HueSensor() = default;
+
+    //! \brief Function to get button event
+    //!
+    //! \return integer representing the button event
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual int getButtonEvent();
+
+    //! \brief Const function to get button event
+    //!
+    //! \note This will not refresh the sensor state
+    //! \return integer representing the button event
+    virtual int getButtonEvent() const;
+
+    //! \brief Function to get sensor status
+    //!
+    //! \return integer representing the status
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual int getStatus();
+
+    //! \brief Const function to get sensor status
+    //!
+    //! \note This will not refresh the sensor state
+    //! \return integer representing the button event
+    virtual int getStatus() const;
+
+    //! \brief Const function to check whether this sensor has a button event
+    //!
+    //! \return Bool that is true when the sensor has specified abilities and false
+    //! when not
+    virtual bool hasButtonEvent() const;
+
+    //! \brief Const function to check whether this sensor has a status
+    //!
+    //! \return Bool that is true when the sensor has specified abilities and false
+    //! when not
+    virtual bool hasStatus() const;
+
+protected:
+    //! \brief Protected ctor that is used by \ref Hue class.
+    //!
+    //! \param id Integer that specifies the id of this sensor
+    //! \param commands HueCommandAPI for communication with the bridge
+    //!
+    //! leaves strategies unset
+    HueSensor(int id, const HueCommandAPI& commands);
+};
+} // namespace hueplusplus
+
+#endif

--- a/include/hueplusplus/HueThing.h
+++ b/include/hueplusplus/HueThing.h
@@ -1,0 +1,159 @@
+/**
+    \file HueThing.h
+    Copyright Notice\n
+    Copyright (C) 2017  Jan Rogall		- developer\n
+    Copyright (C) 2017  Moritz Wirger	- developer\n
+
+    This file is part of hueplusplus.
+
+    hueplusplus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    hueplusplus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with hueplusplus.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#ifndef INCLUDE_HUEPLUSPLUS_HUE_THING_H
+#define INCLUDE_HUEPLUSPLUS_HUE_THING_H
+
+#include <memory>
+
+#include "HueCommandAPI.h"
+
+#include "json/json.hpp"
+
+namespace hueplusplus
+{
+//!
+//! Class for Hue Thing fixtures
+//!
+class HueThing
+{
+public:
+    //! \brief std dtor
+    ~HueThing() = default;
+
+    //! \brief Const function that returns the id of this thing
+    //!
+    //! \return integer representing the thing id
+    virtual int getId() const;
+
+    //! \brief Const function that returns the thing type
+    //!
+    //! \return String containing the type
+    virtual std::string getType() const;
+
+    //! \brief Function that returns the name of the thing.
+    //!
+    //! \return String containig the name of the thing
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual std::string getName();
+
+    //! \brief Const function that returns the name of the thing.
+    //!
+    //! \note This will not refresh the thing state
+    //! \return String containig the name of the thing
+    virtual std::string getName() const;
+
+    //! \brief Const function that returns the modelid of the thing
+    //!
+    //! \return String conatining the modelid
+    virtual std::string getModelId() const;
+
+    //! \brief Const function that returns the uniqueid of the thing
+    //!
+    //! \note Only working on bridges with versions starting at 1.4
+    //! \return String containing the uniqueid or an empty string when the function is not supported
+    virtual std::string getUId() const;
+
+    //! \brief Const function that returns the manufacturername of the thing
+    //!
+    //! \note Only working on bridges with versions starting at 1.7
+    //! \return String containing the manufacturername or an empty string when the function is not supported
+    virtual std::string getManufacturername() const;
+
+    //! \brief Const function that returns the productname of the thing
+    //!
+    //! \note Only working on bridges with versions starting at 1.24
+    //! \return String containing the productname or an empty string when the function is not supported
+    virtual std::string getProductname() const;
+
+    //! \brief Function that returns the software version of the thing
+    //!
+    //! \return String containing the software version
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual std::string getSwVersion();
+
+    //! \brief Const function that returns the software version of the thing
+    //!
+    //! \note This will not refresh the thing state
+    //! \return String containing the software version
+    virtual std::string getSwVersion() const;
+
+    //! \brief Function that sets the name of the thing
+    //!
+    //! \return Bool that is true on success
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual bool setName(const std::string& name);
+
+protected:
+    //! \brief Protected ctor that is used by \ref Hue class.
+    //!
+    //! \param id Integer that specifies the id of this thing
+    //! \param commands HueCommandAPI for communication with the bridge
+    //!
+    //! leaves strategies unset
+    HueThing(int id, const HueCommandAPI& commands, const std::string& path);
+
+    //! \brief Protected function that sets the HueCommandAPI.
+    //!
+    //! The HueCommandAPI is used for bridge communication
+    //! \param commandAPI the new HueCommandAPI
+    virtual void setCommandAPI(const HueCommandAPI& commandAPI) { commands = commandAPI; };
+
+    //! \brief Utility function to send a put request to the thing.
+    //!
+    //! \throws nlohmann::json::parse_error if the reply could not be parsed
+    //! \param request A nlohmann::json aka the request to send
+    //! \param subPath A path that is appended to the uri, note it should always start with a slash ("/")
+    //! \param fileInfo FileInfo from calling function for exception details.
+    //! \return The parsed reply
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual nlohmann::json SendPutRequest(const nlohmann::json& request, const std::string& subPath, FileInfo fileInfo);
+
+    //! \brief Virtual function that refreshes the \ref state of the thing.
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when response contained no body
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
+    virtual void refreshState();
+
+protected:
+    int id; //!< holds the id of the thing
+    std::string path; //!< holds the path of the thing
+    nlohmann::json state; //!< holds the current state of the thing updated by \ref refreshState
+
+    HueCommandAPI commands; //!< A IHttpHandler that is used to communicate with the bridge
+};
+} // namespace hueplusplus
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@ set(hueplusplus_SOURCES
 	HueDeviceTypes.cpp
     HueException.cpp
     HueLight.cpp
+    HueSensor.cpp
+    HueThing.cpp
     SimpleBrightnessStrategy.cpp
     SimpleColorHueStrategy.cpp
     SimpleColorTemperatureStrategy.cpp

--- a/src/HueSensor.cpp
+++ b/src/HueSensor.cpp
@@ -1,0 +1,82 @@
+/**
+    \file HueSensor.cpp
+    Copyright Notice\n
+    Copyright (C) 2020  Stefan Herbrechtsmeier - developer\n
+
+    This file is part of hueplusplus.
+
+    hueplusplus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    hueplusplus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with hueplusplus.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "hueplusplus/HueSensor.h"
+
+#include "hueplusplus/HueThing.h"
+#include "json/json.hpp"
+
+namespace hueplusplus
+{
+int HueSensor::getButtonEvent()
+{
+    refreshState();
+    if (hasButtonEvent())
+    {
+        return state["state"]["buttonevent"];
+    }
+    return 0;
+}
+
+int HueSensor::getButtonEvent() const
+{
+    if (hasButtonEvent())
+    {
+        return state["state"]["buttonevent"];
+    }
+    return 0;
+}
+
+int HueSensor::getStatus()
+{
+    refreshState();
+    if (hasStatus())
+    {
+        return state["state"]["status"];
+    }
+    return 0;
+}
+
+int HueSensor::getStatus() const
+{
+    if (hasStatus())
+    {
+        return state["state"]["status"];
+    }
+    return 0;
+}
+
+bool HueSensor::hasButtonEvent() const
+{
+    return state["state"].count("buttonevent") > 0;
+}
+
+bool HueSensor::hasStatus() const
+{
+    return state["state"].count("status") > 0;
+}
+
+HueSensor::HueSensor(int id, const HueCommandAPI& commands)
+    : HueThing(id, commands, "/sensors/")
+{
+    refreshState();
+}
+} // namespace hueplusplus

--- a/src/HueThing.cpp
+++ b/src/HueThing.cpp
@@ -1,0 +1,136 @@
+/**
+    \file HueThing.cpp
+    Copyright Notice\n
+    Copyright (C) 2020  Stefan Herbrechtsmeier - developer\n
+
+    This file is part of hueplusplus.
+
+    hueplusplus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    hueplusplus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with hueplusplus.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "hueplusplus/HueThing.h"
+
+#include <cmath>
+#include <iostream>
+#include <thread>
+
+#include "hueplusplus/HueExceptionMacro.h"
+#include "hueplusplus/Utils.h"
+#include "json/json.hpp"
+
+namespace hueplusplus
+{
+int HueThing::getId() const
+{
+    return id;
+}
+
+std::string HueThing::getType() const
+{
+    return state["type"];
+}
+
+std::string HueThing::getName()
+{
+    refreshState();
+    return state["name"];
+}
+
+std::string HueThing::getName() const
+{
+    return state["name"];
+}
+
+std::string HueThing::getModelId() const
+{
+    return state["modelid"];
+}
+
+std::string HueThing::getUId() const
+{
+    if (state.count("uniqueid"))
+    {
+        return state["uniqueid"];
+    }
+    return std::string();
+}
+
+std::string HueThing::getManufacturername() const
+{
+    if (state.count("manufacturername"))
+    {
+        return state["manufacturername"];
+    }
+    return std::string();
+}
+
+std::string HueThing::getProductname() const
+{
+    if (state.count("productname"))
+    {
+        return state["productname"];
+    }
+    return std::string();
+}
+
+std::string HueThing::getSwVersion()
+{
+    refreshState();
+    return state["swversion"];
+}
+
+std::string HueThing::getSwVersion() const
+{
+    return state["swversion"];
+}
+
+bool HueThing::setName(const std::string& name)
+{
+    nlohmann::json request = nlohmann::json::object();
+    request["name"] = name;
+    nlohmann::json reply = SendPutRequest(request, "/name", CURRENT_FILE_INFO);
+
+    // Check whether request was successful
+    return utils::safeGetMember(reply, 0, "success", path + std::to_string(id) + "/name") == name;
+}
+
+HueThing::HueThing(int id, const HueCommandAPI& commands, const std::string& path)
+    : id(id),
+      commands(commands),
+      path(path)
+{
+    refreshState();
+}
+
+nlohmann::json HueThing::SendPutRequest(const nlohmann::json& request, const std::string& subPath, FileInfo fileInfo)
+{
+    return commands.PUTRequest(path + std::to_string(id) + subPath, request, std::move(fileInfo));
+}
+
+void HueThing::refreshState()
+{
+    nlohmann::json answer
+        = commands.GETRequest(path + std::to_string(id), nlohmann::json::object(), CURRENT_FILE_INFO);
+    if (answer.count("state"))
+    {
+        state = answer;
+    }
+    else
+    {
+        std::cout << "Answer in HueThing::refreshState of "
+                     "http_handler->GETJson(...) is not expected!\nAnswer:\n\t"
+                  << answer.dump() << std::endl;
+    }
+}
+} // namespace hueplusplus


### PR DESCRIPTION
Add support for Hue sensors. Move common parts from HueLight class to a new HueThing class and add a new HueSensor class.

**Questions**
- Why are all functions are virtual?

**ToDo**
- Move unit tests of HueThing
- Add unit tests for HueSensor

