### PR TITLE
Dynamic light types

### DIFF
--- a/include/hueplusplus/Group.h
+++ b/include/hueplusplus/Group.h
@@ -40,7 +40,7 @@ namespace hueplusplus
 class Group
 {
 public:
-    //! Creates group with id
+    //! \brief Creates group with id
     //! \param id Group id in the bridge
     //! \param commands HueCommandAPI for requests
     //! \param refreshDuration Time between refreshing the cached state.

--- a/include/hueplusplus/Hue.h
+++ b/include/hueplusplus/Hue.h
@@ -35,6 +35,7 @@
 #include "ColorTemperatureStrategy.h"
 #include "Group.h"
 #include "HueCommandAPI.h"
+#include "HueDeviceTypes.h"
 #include "HueLight.h"
 #include "IHttpHandler.h"
 
@@ -245,7 +246,7 @@ public:
     //! \brief Get group specified by id.
     //! \param id ID of the group.
     //! \returns Group that can be controlled.
-    //! \note Every bridge has a special group 0 which contains all lights 
+    //! \note Every bridge has a special group 0 which contains all lights
     //! and is not visible to getAllGroups().
     //! \throws std::system_error when system or socket operations fail
     //! \throws HueException when id does not exist
@@ -318,21 +319,11 @@ private:
     std::map<uint8_t, HueLight> lights; //!< Maps ids to HueLights that are controlled by this bridge
     std::map<uint8_t, Group> groups; //!< Maps ids to Groups
 
-    std::shared_ptr<BrightnessStrategy> simpleBrightnessStrategy; //!< Strategy that is used for controlling the
-                                                                  //!< brightness of lights
-    std::shared_ptr<ColorHueStrategy> simpleColorHueStrategy; //!< Strategy that is used for controlling the
-                                                              //!< color of lights
-    std::shared_ptr<ColorHueStrategy> extendedColorHueStrategy; //!< Strategy that is used for controlling the
-                                                                //!< color of lights
-    std::shared_ptr<ColorTemperatureStrategy> simpleColorTemperatureStrategy; //!< Strategy that is used for controlling
-                                                                              //!< the color temperature of lights
-    std::shared_ptr<ColorTemperatureStrategy> extendedColorTemperatureStrategy; //!< Strategy that is used for
-                                                                                //!< controlling the color
-                                                                                //!< temperature of lights
     std::shared_ptr<const IHttpHandler> http_handler; //!< A IHttpHandler that is used to communicate with the
                                                       //!< bridge
     HueCommandAPI commands; //!< A HueCommandAPI that is used to communicate with the bridge
     APICache stateCache; //!< The state of the hue bridge as it is returned from it
+    HueLightFactory lightFactory;
 };
 } // namespace hueplusplus
 

--- a/include/hueplusplus/HueDeviceTypes.h
+++ b/include/hueplusplus/HueDeviceTypes.h
@@ -33,12 +33,16 @@ namespace hueplusplus
 class HueLightFactory
 {
 public:
-    HueLightFactory(const HueCommandAPI& commands);
+    HueLightFactory(const HueCommandAPI& commands, std::chrono::steady_clock::duration refreshDuration);
 
     HueLight createLight(const nlohmann::json& lightState, int id);
 
 private:
+    ColorType getColorType(const nlohmann::json& lightState, bool hasCt) const;
+
+private:
     HueCommandAPI commands;
+    std::chrono::steady_clock::duration refreshDuration;
     std::shared_ptr<BrightnessStrategy> simpleBrightness;
     std::shared_ptr<ColorTemperatureStrategy> simpleColorTemperature;
     std::shared_ptr<ColorTemperatureStrategy> extendedColorTemperature;

--- a/include/hueplusplus/HueDeviceTypes.h
+++ b/include/hueplusplus/HueDeviceTypes.h
@@ -33,11 +33,28 @@ namespace hueplusplus
 class HueLightFactory
 {
 public:
+    //! \brief Create a factory for HueLight%s
+    //! \param commands HueCommandAPI for communication with the bridge
+    //! \param refreshDuration Time between refreshing the cached light state.
     HueLightFactory(const HueCommandAPI& commands, std::chrono::steady_clock::duration refreshDuration);
 
+    //! \brief Create a HueLight with the correct type from the JSON state.
+    //! \param lightState Light JSON as returned from the bridge (not only the "state" part of it).
+    //! \param id Light id.
+    //! \returns HueLight with matching id, strategies and \ref ColorType.
+    //! \throws std::system_error when system or socket operations fail
+    //! \throws HueException when light type is unknown
+    //! \throws HueAPIResponseException when response contains an error
+    //! \throws nlohmann::json::parse_error when response could not be parsed
     HueLight createLight(const nlohmann::json& lightState, int id);
 
 private:
+    //! \brief Get color type from light JSON.
+    //! \param lightState Light JSON as returned from the bridge (not only the "state" part of it).
+    //! \param hasCt Whether the light has color temperature control.
+    //! \returns The color gamut specified in the light capabilities or,
+    //! if that does not exist, from a set of known models. Returns GAMUT_X_TEMPERATURE when \ref hasCt is true.
+    //! \throws HueException when the light has no capabilities and the model is not known.
     ColorType getColorType(const nlohmann::json& lightState, bool hasCt) const;
 
 private:

--- a/include/hueplusplus/HueDeviceTypes.h
+++ b/include/hueplusplus/HueDeviceTypes.h
@@ -35,7 +35,7 @@ class HueLightFactory
 public:
     HueLightFactory(const HueCommandAPI& commands);
 
-    HueLight createLight(const std::string& type, int id);
+    HueLight createLight(const nlohmann::json& lightState, int id);
 
 private:
     HueCommandAPI commands;

--- a/include/hueplusplus/HueDeviceTypes.h
+++ b/include/hueplusplus/HueDeviceTypes.h
@@ -30,14 +30,20 @@
 
 namespace hueplusplus
 {
-struct MakeHueLight
+class HueLightFactory
 {
-    auto operator()(std::string type, int id, HueCommandAPI commands,
-        std::shared_ptr<BrightnessStrategy> simpleBrightnessStrategy,
-        std::shared_ptr<ColorTemperatureStrategy> extendedColorTemperatureStrategy,
-        std::shared_ptr<ColorTemperatureStrategy> simpleColorTemperatureStrategy,
-        std::shared_ptr<ColorHueStrategy> extendedColorHueStrategy,
-        std::shared_ptr<ColorHueStrategy> simpleColorHueStrategy) -> HueLight;
+public:
+    HueLightFactory(const HueCommandAPI& commands);
+
+    HueLight createLight(const std::string& type, int id);
+
+private:
+    HueCommandAPI commands;
+    std::shared_ptr<BrightnessStrategy> simpleBrightness;
+    std::shared_ptr<ColorTemperatureStrategy> simpleColorTemperature;
+    std::shared_ptr<ColorTemperatureStrategy> extendedColorTemperature;
+    std::shared_ptr<ColorHueStrategy> simpleColorHue;
+    std::shared_ptr<ColorHueStrategy> extendedColorHue;
 };
 } // namespace hueplusplus
 

--- a/include/hueplusplus/HueLight.h
+++ b/include/hueplusplus/HueLight.h
@@ -97,8 +97,7 @@ enum class ColorType
 //! Provides methods to query and control lights.
 class HueLight
 {
-    friend class Hue;
-    friend struct MakeHueLight;
+    friend class HueLightFactory;
     friend class SimpleBrightnessStrategy;
     friend class SimpleColorHueStrategy;
     friend class ExtendedColorHueStrategy;

--- a/include/hueplusplus/HueLight.h
+++ b/include/hueplusplus/HueLight.h
@@ -118,7 +118,13 @@ public:
 
     //! \brief Const function that returns the light type
     //!
+    //! The type determines which functions the light has.
     //! \return String containing the type
+    //! - "On/Off light": on/off
+    //! - "Dimmable light": on/off, brightness
+    //! - "Color light": on/off, brightness, color hue/sat/xy
+    //! - "Color temperature light": on/off, brightness, color temperature
+    //! - "Extended color light": on/off, brightness, color temperature, color hue/sat/xy
     virtual std::string getType() const;
 
     //! \brief Function that returns the name of the light.

--- a/include/hueplusplus/HueLight.h
+++ b/include/hueplusplus/HueLight.h
@@ -83,13 +83,13 @@ enum class ColorType
 {
     UNDEFINED, //!< ColorType for this light is unknown or undefined
     NONE, //!< light has no specific ColorType
-    GAMUT_A,
-    GAMUT_B,
-    GAMUT_C,
-    TEMPERATURE,
-    GAMUT_A_TEMPERATURE,
-    GAMUT_B_TEMPERATURE,
-    GAMUT_C_TEMPERATURE
+    GAMUT_A, //!< light uses Gamut A
+    GAMUT_B, //!< light uses Gamut B
+    GAMUT_C, //!< light uses Gamut C
+    TEMPERATURE, //!< light has color temperature control
+    GAMUT_A_TEMPERATURE, //!< light uses Gamut A and has color temperature control
+    GAMUT_B_TEMPERATURE, //!< light uses Gamut B and has color temperature control
+    GAMUT_C_TEMPERATURE //!< light uses Gamut C and has color temperature control
 };
 
 //! \brief Class for Hue Light fixtures

--- a/src/Hue.cpp
+++ b/src/Hue.cpp
@@ -137,7 +137,7 @@ Hue::Hue(const std::string& ip, const int port, const std::string& username,
       http_handler(std::move(handler)),
       commands(ip, port, username, http_handler),
       stateCache("", commands, refreshDuration),
-      lightFactory(commands)
+      lightFactory(commands, refreshDuration)
 {}
 
 std::string Hue::getBridgeIP()
@@ -179,9 +179,7 @@ std::string Hue::requestUsername()
                 // [{"success":{"username": "<username>"}}]
                 username = jsonUser.get<std::string>();
                 // Update commands with new username and ip
-                commands = HueCommandAPI(ip, port, username, http_handler);
-                stateCache = APICache("", commands, stateCache.getRefreshDuration());
-                lightFactory = HueLightFactory(commands);
+                setHttpHandler(http_handler);
                 std::cout << "Success! Link button was pressed!\n";
                 std::cout << "Username is \"" << username << "\"\n";
                 break;
@@ -523,6 +521,6 @@ void Hue::setHttpHandler(std::shared_ptr<const IHttpHandler> handler)
     http_handler = handler;
     commands = HueCommandAPI(ip, port, username, handler);
     stateCache = APICache("", commands, stateCache.getRefreshDuration());
-    lightFactory = HueLightFactory(commands);
+    lightFactory = HueLightFactory(commands, stateCache.getRefreshDuration());
 }
 } // namespace hueplusplus

--- a/src/Hue.cpp
+++ b/src/Hue.cpp
@@ -231,8 +231,7 @@ HueLight& Hue::getLight(int id)
         std::cerr << "Error in Hue getLight(): light with id " << id << " is not valid\n";
         throw HueException(CURRENT_FILE_INFO, "Light id is not valid");
     }
-    std::string type = lightsCache[std::to_string(id)]["modelid"];
-    auto light = lightFactory.createLight(type, id);
+    auto light = lightFactory.createLight(lightsCache[std::to_string(id)], id);
     lights.emplace(id, light);
     return lights.find(id)->second;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
 	test_Group.cpp
     test_Hue.cpp
     test_HueLight.cpp
+    test_HueLightFactory.cpp
     test_HueCommandAPI.cpp
     test_Main.cpp
     test_SimpleBrightnessStrategy.cpp

--- a/test/test_Group.cpp
+++ b/test/test_Group.cpp
@@ -270,12 +270,18 @@ TEST(CreateGroup, Entertainment)
         CreateGroup::Entertainment({2, 4}).getRequest());
 }
 
+TEST(CreateGroup, Zone)
+{
+    EXPECT_EQ(nlohmann::json({{"lights", {"1"}}, {"type", "Zone"}, {"name", "Name"}}),
+        CreateGroup::Zone({1}, "Name").getRequest());
+    EXPECT_EQ(nlohmann::json({{"lights", {"2", "4"}}, {"type", "Zone"}}), CreateGroup::Zone({2, 4}).getRequest());
+}
+
 TEST(CreateGroup, Room)
 {
     EXPECT_EQ(nlohmann::json({{"lights", {"1"}}, {"type", "Room"}, {"name", "Name"}, {"class", "Bedroom"}}),
         CreateGroup::Room({1}, "Name", "Bedroom").getRequest());
     EXPECT_EQ(nlohmann::json({{"lights", {"1"}}, {"type", "Room"}, {"name", "Name"}}),
         CreateGroup::Room({1}, "Name").getRequest());
-    EXPECT_EQ(
-        nlohmann::json({{"lights", {"2", "4"}}, {"type", "Room"}}), CreateGroup::Room({2, 4}).getRequest());
+    EXPECT_EQ(nlohmann::json({{"lights", {"2", "4"}}, {"type", "Room"}}), CreateGroup::Room({2, 4}).getRequest());
 }

--- a/test/test_Hue.cpp
+++ b/test/test_Hue.cpp
@@ -298,6 +298,7 @@ TEST(Hue, getLight)
     EXPECT_EQ(test_light_1.getColorType(), ColorType::TEMPERATURE);
 
     // more coverage stuff
+    hue_bridge_state["lights"]["1"]["type"] = "Color light";
     hue_bridge_state["lights"]["1"]["modelid"] = "LCT001";
     EXPECT_CALL(
         *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
@@ -349,7 +350,7 @@ TEST(Hue, getLight)
     EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
     EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_A);
 
-    hue_bridge_state["lights"]["1"]["modelid"] = "LWB004";
+    hue_bridge_state["lights"]["1"]["type"] = "Dimmable light";
     EXPECT_CALL(
         *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
         .Times(1)
@@ -366,7 +367,7 @@ TEST(Hue, getLight)
     EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
     EXPECT_EQ(test_light_1.getColorType(), ColorType::NONE);
 
-    hue_bridge_state["lights"]["1"]["modelid"] = "Plug 01";
+    hue_bridge_state["lights"]["1"]["type"] = "On/Off light";
     EXPECT_CALL(
         *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
         .Times(1)
@@ -383,7 +384,7 @@ TEST(Hue, getLight)
     EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
     EXPECT_EQ(test_light_1.getColorType(), ColorType::NONE);
 
-    hue_bridge_state["lights"]["1"]["modelid"] = "ABC000";
+    hue_bridge_state["lights"]["1"]["type"] = "unknown light type";
     EXPECT_CALL(
         *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
         .Times(1)

--- a/test/test_Hue.cpp
+++ b/test/test_Hue.cpp
@@ -296,101 +296,6 @@ TEST(Hue, getLight)
     test_light_1 = test_bridge.getLight(1);
     EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
     EXPECT_EQ(test_light_1.getColorType(), ColorType::TEMPERATURE);
-
-    // more coverage stuff
-    hue_bridge_state["lights"]["1"]["type"] = "Color light";
-    hue_bridge_state["lights"]["1"]["modelid"] = "LCT001";
-    EXPECT_CALL(
-        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(1)
-        .WillOnce(Return(hue_bridge_state));
-
-    EXPECT_CALL(*handler,
-        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(AtLeast(1))
-        .WillRepeatedly(Return(hue_bridge_state["lights"]["1"]));
-    test_bridge = Hue(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
-
-    // Test when correct data is sent
-    test_light_1 = test_bridge.getLight(1);
-    EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
-    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_B);
-
-    hue_bridge_state["lights"]["1"]["modelid"] = "LCT010";
-    EXPECT_CALL(
-        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(1)
-        .WillOnce(Return(hue_bridge_state));
-
-    EXPECT_CALL(*handler,
-        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(AtLeast(1))
-        .WillRepeatedly(Return(hue_bridge_state["lights"]["1"]));
-    test_bridge = Hue(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
-
-    // Test when correct data is sent
-    test_light_1 = test_bridge.getLight(1);
-    EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
-    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_C);
-
-    hue_bridge_state["lights"]["1"]["modelid"] = "LST001";
-    EXPECT_CALL(
-        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(1)
-        .WillOnce(Return(hue_bridge_state));
-
-    EXPECT_CALL(*handler,
-        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(AtLeast(1))
-        .WillRepeatedly(Return(hue_bridge_state["lights"]["1"]));
-    test_bridge = Hue(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
-
-    // Test when correct data is sent
-    test_light_1 = test_bridge.getLight(1);
-    EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
-    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_A);
-
-    hue_bridge_state["lights"]["1"]["type"] = "Dimmable light";
-    EXPECT_CALL(
-        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(1)
-        .WillOnce(Return(hue_bridge_state));
-
-    EXPECT_CALL(*handler,
-        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(AtLeast(1))
-        .WillRepeatedly(Return(hue_bridge_state["lights"]["1"]));
-    test_bridge = Hue(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
-
-    // Test when correct data is sent
-    test_light_1 = test_bridge.getLight(1);
-    EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
-    EXPECT_EQ(test_light_1.getColorType(), ColorType::NONE);
-
-    hue_bridge_state["lights"]["1"]["type"] = "On/Off light";
-    EXPECT_CALL(
-        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(1)
-        .WillOnce(Return(hue_bridge_state));
-
-    EXPECT_CALL(*handler,
-        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(AtLeast(1))
-        .WillRepeatedly(Return(hue_bridge_state["lights"]["1"]));
-    test_bridge = Hue(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
-
-    // Test when correct data is sent
-    test_light_1 = test_bridge.getLight(1);
-    EXPECT_EQ(test_light_1.getName(), "Hue ambiance lamp 1");
-    EXPECT_EQ(test_light_1.getColorType(), ColorType::NONE);
-
-    hue_bridge_state["lights"]["1"]["type"] = "unknown light type";
-    EXPECT_CALL(
-        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
-        .Times(1)
-        .WillOnce(Return(hue_bridge_state));
-    test_bridge = Hue(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
-    ASSERT_THROW(test_bridge.getLight(1), HueException);
 }
 
 TEST(Hue, removeLight)
@@ -659,6 +564,9 @@ TEST(Hue, createGroup)
 {
     using namespace ::testing;
     std::shared_ptr<MockHttpHandler> handler = std::make_shared<MockHttpHandler>();
+    EXPECT_CALL(
+        *handler, GETJson("/api/" + getBridgeUsername(), nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1));
     Hue test_bridge(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler);
     CreateGroup create = CreateGroup::Room({2, 3}, "Nice room", "LivingRoom");
     nlohmann::json request = create.getRequest();

--- a/test/test_HueLight.cpp
+++ b/test/test_HueLight.cpp
@@ -103,7 +103,7 @@ protected:
         hue_bridge_state["lights"]["3"]["swupdate"] = nlohmann::json::object();
         hue_bridge_state["lights"]["3"]["swupdate"]["state"] = "noupdates";
         hue_bridge_state["lights"]["3"]["swupdate"]["lastinstall"] = nullptr;
-        hue_bridge_state["lights"]["3"]["type"] = "Color extended light";
+        hue_bridge_state["lights"]["3"]["type"] = "Extended color light";
         hue_bridge_state["lights"]["3"]["name"] = "Hue lamp 3";
         hue_bridge_state["lights"]["3"]["modelid"] = "LCT010";
         hue_bridge_state["lights"]["3"]["manufacturername"] = "Philips";
@@ -236,10 +236,10 @@ TEST_F(HueLightTest, getType)
 
     EXPECT_EQ("Dimmable light", ctest_light_1.getType());
     EXPECT_EQ("Color light", ctest_light_2.getType());
-    EXPECT_EQ("Color extended light", ctest_light_3.getType());
+    EXPECT_EQ("Extended color light", ctest_light_3.getType());
     EXPECT_EQ("Dimmable light", test_light_1.getType());
     EXPECT_EQ("Color light", test_light_2.getType());
-    EXPECT_EQ("Color extended light", test_light_3.getType());
+    EXPECT_EQ("Extended color light", test_light_3.getType());
 }
 
 TEST_F(HueLightTest, getName)
@@ -406,10 +406,10 @@ TEST_F(HueLightTest, getColorType)
 
     EXPECT_EQ(ColorType::NONE, ctest_light_1.getColorType());
     EXPECT_EQ(ColorType::GAMUT_A, ctest_light_2.getColorType());
-    EXPECT_EQ(ColorType::GAMUT_C, ctest_light_3.getColorType());
+    EXPECT_EQ(ColorType::GAMUT_C_TEMPERATURE, ctest_light_3.getColorType());
     EXPECT_EQ(ColorType::NONE, test_light_1.getColorType());
     EXPECT_EQ(ColorType::GAMUT_A, test_light_2.getColorType());
-    EXPECT_EQ(ColorType::GAMUT_C, test_light_3.getColorType());
+    EXPECT_EQ(ColorType::GAMUT_C_TEMPERATURE, test_light_3.getColorType());
 }
 
 TEST_F(HueLightTest, KelvinToMired)

--- a/test/test_HueLightFactory.cpp
+++ b/test/test_HueLightFactory.cpp
@@ -1,0 +1,243 @@
+/**
+    \file test_HueLightFactory.cpp
+    Copyright Notice\n
+    Copyright (C) 2020  Jan Rogall		- developer\n
+    Copyright (C) 2020  Moritz Wirger	- developer\n
+
+    This file is part of hueplusplus.
+
+    hueplusplus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    hueplusplus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with hueplusplus.  If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include <gtest/gtest.h>
+#include <hueplusplus/HueDeviceTypes.h>
+
+#include "testhelper.h"
+
+#include "mocks/mock_HttpHandler.h"
+
+using namespace hueplusplus;
+
+TEST(HueLightFactory, createLight_noGamut)
+{
+    using namespace ::testing;
+    std::shared_ptr<MockHttpHandler> handler = std::make_shared<MockHttpHandler>();
+
+    HueLightFactory factory(HueCommandAPI(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler),
+        std::chrono::steady_clock::duration::max());
+
+    nlohmann::json lightState
+        = {{"state",
+               {{"on", true}, {"bri", 254}, {"ct", 366}, {"alert", "none"}, {"colormode", "ct"}, {"reachable", true}}},
+            {"swupdate", {{"state", "noupdates"}, {"lastinstall", nullptr}}}, {"type", "Color temperature light"},
+            {"name", "Hue ambiance lamp 1"}, {"modelid", "LTW001"}, {"manufacturername", "Philips"},
+            {"uniqueid", "00:00:00:00:00:00:00:00-00"}, {"swversion", "5.50.1.19085"}};
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    HueLight test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::TEMPERATURE);
+
+    lightState["type"] = "Dimmable light";
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::NONE);
+
+    lightState["type"] = "On/Off light";
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::NONE);
+
+    lightState["type"] = "unknown light type";
+    ASSERT_THROW(factory.createLight(lightState, 1), HueException);
+}
+
+TEST(HueLightFactory, createLight_gamutCapabilities)
+{
+    using namespace ::testing;
+    std::shared_ptr<MockHttpHandler> handler = std::make_shared<MockHttpHandler>();
+
+    HueLightFactory factory(HueCommandAPI(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler),
+        std::chrono::steady_clock::duration::max());
+
+    nlohmann::json lightState
+        = { {"state",
+               {{"on", true}, {"bri", 254}, {"ct", 366}, {"alert", "none"}, {"colormode", "ct"}, {"reachable", true}}},
+            {"swupdate", {{"state", "noupdates"}, {"lastinstall", nullptr}}}, {"type", "Color light"},
+            {"name", "Hue ambiance lamp 1"}, {"modelid", "LTW001"}, {"manufacturername", "Philips"},
+            {"uniqueid", "00:00:00:00:00:00:00:00-00"}, {"swversion", "5.50.1.19085"},
+            {"capabilities", {{"control", {{"colorgamuttype", "A"}}}}} };
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    HueLight test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_A);
+
+    lightState["capabilities"]["control"]["colorgamuttype"] = "B";
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_B);
+
+    lightState["capabilities"]["control"]["colorgamuttype"] = "C";
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_C);
+
+    lightState["capabilities"]["control"]["colorgamuttype"] = "Other";
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::UNDEFINED);
+
+    // With color temperature
+    lightState["type"] = "Extended color light";
+    lightState["capabilities"]["control"]["colorgamuttype"] = "A";
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_A_TEMPERATURE);
+
+    lightState["capabilities"]["control"]["colorgamuttype"] = "B";
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_B_TEMPERATURE);
+
+    lightState["capabilities"]["control"]["colorgamuttype"] = "C";
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_C_TEMPERATURE);
+}
+
+TEST(HueLightFactory, createLight_gamutModelid)
+{
+    using namespace ::testing;
+    std::shared_ptr<MockHttpHandler> handler = std::make_shared<MockHttpHandler>();
+
+    HueLightFactory factory(HueCommandAPI(getBridgeIp(), getBridgePort(), getBridgeUsername(), handler),
+        std::chrono::steady_clock::duration::max());
+
+    const std::string gamutAModel = "LST001";
+    const std::string gamutBModel = "LCT001";
+    const std::string gamutCModel = "LCT010";
+
+    nlohmann::json lightState
+        = {{"state",
+               {{"on", true}, {"bri", 254}, {"ct", 366}, {"alert", "none"}, {"colormode", "ct"}, {"reachable", true}}},
+            {"swupdate", {{"state", "noupdates"}, {"lastinstall", nullptr}}}, {"type", "Color light"},
+            {"name", "Hue ambiance lamp 1"}, {"modelid", gamutAModel}, {"manufacturername", "Philips"},
+            {"uniqueid", "00:00:00:00:00:00:00:00-00"}, {"swversion", "5.50.1.19085"}};
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    HueLight test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_A);
+
+    lightState["modelid"] = gamutBModel;
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_B);
+
+    lightState["modelid"] = gamutCModel;
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_C);
+
+    // With color temperature
+    lightState["type"] = "Extended color light";
+    lightState["modelid"] = gamutAModel;
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_A_TEMPERATURE);
+
+    lightState["modelid"] = gamutBModel;
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_B_TEMPERATURE);
+
+    lightState["modelid"] = gamutCModel;
+
+    EXPECT_CALL(*handler,
+        GETJson("/api/" + getBridgeUsername() + "/lights/1", nlohmann::json::object(), getBridgeIp(), getBridgePort()))
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(lightState));
+
+    test_light_1 = factory.createLight(lightState, 1);
+    EXPECT_EQ(test_light_1.getColorType(), ColorType::GAMUT_C_TEMPERATURE);
+
+    // Unknown model
+    lightState["modelid"] = "Unknown model";
+    EXPECT_THROW(factory.createLight(lightState, 1), HueException);
+}


### PR DESCRIPTION
Uses the type and the capabilities field to find out which type a light has.
This way, no hardware models need to be added manually. The old types have been left in for compatibility.
@sieren, @herbrechtsmeier could you verify that this works with all light types you have access to?