### PR TITLE
Remove all uses of implicit conversions from json.

### DIFF
--- a/hueplusplus/ExtendedColorHueStrategy.cpp
+++ b/hueplusplus/ExtendedColorHueStrategy.cpp
@@ -31,12 +31,12 @@
 bool ExtendedColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorHueSaturation(hue, sat, 1))
         {
             return false;
@@ -59,8 +59,8 @@ bool ExtendedColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, Hue
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorHueSaturation(hue, sat, 1))
         {
             return false;
@@ -83,7 +83,7 @@ bool ExtendedColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, Hue
     }
     else if (cType == "ct")
     {
-        uint16_t oldCT = light.state["state"]["ct"];
+        uint16_t oldCT = light.state["state"]["ct"].get<uint16_t>();
         if (!light.setColorHueSaturation(hue, sat, 1))
         {
             return false;
@@ -113,12 +113,12 @@ bool ExtendedColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, Hue
 bool ExtendedColorHueStrategy::alertXY(float x, float y, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorXY(x, y, 1))
         {
             return false;
@@ -141,8 +141,8 @@ bool ExtendedColorHueStrategy::alertXY(float x, float y, HueLight& light) const
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorXY(x, y, 1))
         {
             return false;
@@ -165,7 +165,7 @@ bool ExtendedColorHueStrategy::alertXY(float x, float y, HueLight& light) const
     }
     else if (cType == "ct")
     {
-        uint16_t oldCT = light.state["state"]["ct"];
+        uint16_t oldCT = light.state["state"]["ct"].get<uint16_t>();
         if (!light.setColorXY(x, y, 1))
         {
             return false;
@@ -195,12 +195,12 @@ bool ExtendedColorHueStrategy::alertXY(float x, float y, HueLight& light) const
 bool ExtendedColorHueStrategy::alertRGB(uint8_t r, uint8_t g, uint8_t b, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorRGB(r, g, b, 1))
         {
             return false;
@@ -223,8 +223,8 @@ bool ExtendedColorHueStrategy::alertRGB(uint8_t r, uint8_t g, uint8_t b, HueLigh
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorRGB(r, g, b, 1))
         {
             return false;
@@ -247,7 +247,7 @@ bool ExtendedColorHueStrategy::alertRGB(uint8_t r, uint8_t g, uint8_t b, HueLigh
     }
     else if (cType == "ct")
     {
-        uint16_t oldCT = light.state["state"]["ct"];
+        uint16_t oldCT = light.state["state"]["ct"].get<uint16_t>();
         if (!light.setColorRGB(r, g, b, 1))
         {
             return false;

--- a/hueplusplus/ExtendedColorTemperatureStrategy.cpp
+++ b/hueplusplus/ExtendedColorTemperatureStrategy.cpp
@@ -71,12 +71,12 @@ bool ExtendedColorTemperatureStrategy::setColorTemperature(
 bool ExtendedColorTemperatureStrategy::alertTemperature(unsigned int mired, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorTemperature(mired, 1))
         {
             return false;
@@ -99,8 +99,8 @@ bool ExtendedColorTemperatureStrategy::alertTemperature(unsigned int mired, HueL
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorTemperature(mired, 1))
         {
             return false;
@@ -123,7 +123,7 @@ bool ExtendedColorTemperatureStrategy::alertTemperature(unsigned int mired, HueL
     }
     else if (cType == "ct")
     {
-        uint16_t oldCT = light.state["state"]["ct"];
+        uint16_t oldCT = light.state["state"]["ct"].get<uint16_t>();
         if (!light.setColorTemperature(mired, 1))
         {
             return false;

--- a/hueplusplus/Hue.cpp
+++ b/hueplusplus/Hue.cpp
@@ -183,7 +183,7 @@ std::string Hue::requestUsername()
             if (jsonUser != nullptr)
             {
                 // [{"success":{"username": "<username>"}}]
-                username = jsonUser;
+                username = jsonUser.get<std::string>();
                 // Update commands with new username and ip
                 commands = HueCommandAPI(ip, port, username, http_handler);
                 std::cout << "Success! Link button was pressed!\n";
@@ -235,7 +235,7 @@ HueLight& Hue::getLight(int id)
         throw HueException(CURRENT_FILE_INFO, "Light id is not valid");
     }
     // std::cout << state["lights"][std::to_string(id)] << std::endl;
-    std::string type = state["lights"][std::to_string(id)]["modelid"];
+    std::string type = state["lights"][std::to_string(id)]["modelid"].get<std::string>();
     // std::cout << type << std::endl;
     if (type == "LCT001" || type == "LCT002" || type == "LCT003" || type == "LCT007" || type == "LLM001")
     {

--- a/hueplusplus/HueLight.cpp
+++ b/hueplusplus/HueLight.cpp
@@ -45,12 +45,12 @@ bool HueLight::Off(uint8_t transition)
 bool HueLight::isOn()
 {
     refreshState();
-    return state["state"]["on"];
+    return state["state"]["on"].get<bool>();
 }
 
 bool HueLight::isOn() const
 {
-    return state["state"]["on"];
+    return state["state"]["on"].get<bool>();
 }
 
 int HueLight::getId() const
@@ -60,30 +60,30 @@ int HueLight::getId() const
 
 std::string HueLight::getType() const
 {
-    return state["type"];
+    return state["type"].get<std::string>();
 }
 
 std::string HueLight::getName()
 {
     refreshState();
-    return state["name"];
+    return state["name"].get<std::string>();
 }
 
 std::string HueLight::getName() const
 {
-    return state["name"];
+    return state["name"].get<std::string>();
 }
 
 std::string HueLight::getModelId() const
 {
-    return state["modelid"];
+    return state["modelid"].get<std::string>();
 }
 
 std::string HueLight::getUId() const
 {
     if (state.count("uniqueid"))
     {
-        return state["uniqueid"];
+        return state["uniqueid"].get<std::string>();
     }
     return std::string();
 }
@@ -92,7 +92,7 @@ std::string HueLight::getManufacturername() const
 {
     if (state.count("manufacturername"))
     {
-        return state["manufacturername"];
+        return state["manufacturername"].get<std::string>();
     }
     return std::string();
 }
@@ -101,7 +101,7 @@ std::string HueLight::getProductname() const
 {
     if (state.count("productname"))
     {
-        return state["productname"];
+        return state["productname"].get<std::string>();
     }
     return std::string();
 }
@@ -110,7 +110,7 @@ std::string HueLight::getLuminaireUId() const
 {
     if (state.count("luminaireuniqueid"))
     {
-        return state["luminaireuniqueid"];
+        return state["luminaireuniqueid"].get<std::string>();
     }
     return std::string();
 }
@@ -118,12 +118,12 @@ std::string HueLight::getLuminaireUId() const
 std::string HueLight::getSwVersion()
 {
     refreshState();
-    return state["swversion"];
+    return state["swversion"].get<std::string>();
 }
 
 std::string HueLight::getSwVersion() const
 {
-    return state["swversion"];
+    return state["swversion"].get<std::string>();
 }
 
 bool HueLight::setName(const std::string& name)

--- a/hueplusplus/SimpleBrightnessStrategy.cpp
+++ b/hueplusplus/SimpleBrightnessStrategy.cpp
@@ -79,10 +79,10 @@ bool SimpleBrightnessStrategy::setBrightness(unsigned int bri, uint8_t transitio
 unsigned int SimpleBrightnessStrategy::getBrightness(HueLight& light) const
 {
     light.refreshState();
-    return light.state["state"]["bri"];
+    return light.state["state"]["bri"].get<unsigned int>();
 }
 
 unsigned int SimpleBrightnessStrategy::getBrightness(const HueLight& light) const
 {
-    return light.state["state"]["bri"];
+    return light.state["state"]["bri"].get<unsigned int>();
 }

--- a/hueplusplus/SimpleColorHueStrategy.cpp
+++ b/hueplusplus/SimpleColorHueStrategy.cpp
@@ -221,12 +221,12 @@ bool SimpleColorHueStrategy::setColorLoop(bool on, HueLight& light) const
 bool SimpleColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorHueSaturation(hue, sat, 1))
         {
             return false;
@@ -249,8 +249,8 @@ bool SimpleColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, HueLi
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorHueSaturation(hue, sat, 1))
         {
             return false;
@@ -280,12 +280,12 @@ bool SimpleColorHueStrategy::alertHueSaturation(uint16_t hue, uint8_t sat, HueLi
 bool SimpleColorHueStrategy::alertXY(float x, float y, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorXY(x, y, 1))
         {
             return false;
@@ -308,8 +308,8 @@ bool SimpleColorHueStrategy::alertXY(float x, float y, HueLight& light) const
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorXY(x, y, 1))
         {
             return false;
@@ -339,12 +339,12 @@ bool SimpleColorHueStrategy::alertXY(float x, float y, HueLight& light) const
 bool SimpleColorHueStrategy::alertRGB(uint8_t r, uint8_t g, uint8_t b, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "hs")
     {
-        uint16_t oldHue = light.state["state"]["hue"];
-        uint8_t oldSat = light.state["state"]["sat"];
+        uint16_t oldHue = light.state["state"]["hue"].get<uint16_t>();
+        uint8_t oldSat = light.state["state"]["sat"].get<uint8_t>();
         if (!light.setColorRGB(r, g, b, 1))
         {
             return false;
@@ -367,8 +367,8 @@ bool SimpleColorHueStrategy::alertRGB(uint8_t r, uint8_t g, uint8_t b, HueLight&
     }
     else if (cType == "xy")
     {
-        float oldX = light.state["state"]["xy"][0];
-        float oldY = light.state["state"]["xy"][1];
+        float oldX = light.state["state"]["xy"][0].get<float>();
+        float oldY = light.state["state"]["xy"][1].get<float>();
         if (!light.setColorRGB(r, g, b, 1))
         {
             return false;
@@ -398,25 +398,23 @@ bool SimpleColorHueStrategy::alertRGB(uint8_t r, uint8_t g, uint8_t b, HueLight&
 std::pair<uint16_t, uint8_t> SimpleColorHueStrategy::getColorHueSaturation(HueLight& light) const
 {
     light.refreshState();
-    return std::pair<uint16_t, uint8_t>(
-        static_cast<uint16_t>(light.state["state"]["hue"]), static_cast<uint8_t>(light.state["state"]["sat"]));
+    return std::make_pair(light.state["state"]["hue"].get<uint16_t>(), light.state["state"]["sat"].get<uint8_t>());
 }
 
 std::pair<uint16_t, uint8_t> SimpleColorHueStrategy::getColorHueSaturation(const HueLight& light) const
 {
-    return std::pair<uint16_t, uint8_t>(
-        static_cast<uint16_t>(light.state["state"]["hue"]), static_cast<uint8_t>(light.state["state"]["sat"]));
+    return std::make_pair(light.state["state"]["hue"].get<uint16_t>(), light.state["state"]["sat"].get<uint8_t>());
 }
 
 std::pair<float, float> SimpleColorHueStrategy::getColorXY(HueLight& light) const
 {
     light.refreshState();
-    return std::pair<float, float>(light.state["state"]["xy"][0], light.state["state"]["xy"][1]);
+    return std::make_pair(light.state["state"]["xy"][0].get<float>(), light.state["state"]["xy"][1].get<float>());
 }
 
 std::pair<float, float> SimpleColorHueStrategy::getColorXY(const HueLight& light) const
 {
-    return std::pair<float, float>(light.state["state"]["xy"][0], light.state["state"]["xy"][1]);
+    return std::make_pair(light.state["state"]["xy"][0].get<float>(), light.state["state"]["xy"][1].get<float>());
 }
 /*bool SimpleColorHueStrategy::pointInTriangle(float pointx, float pointy, float
 x0, float y0, float x1, float y1, float x2, float y2)

--- a/hueplusplus/SimpleColorTemperatureStrategy.cpp
+++ b/hueplusplus/SimpleColorTemperatureStrategy.cpp
@@ -70,11 +70,11 @@ bool SimpleColorTemperatureStrategy::setColorTemperature(unsigned int mired, uin
 bool SimpleColorTemperatureStrategy::alertTemperature(unsigned int mired, HueLight& light) const
 {
     light.refreshState();
-    std::string cType = light.state["state"]["colormode"];
-    bool on = light.state["state"]["on"];
+    std::string cType = light.state["state"]["colormode"].get<std::string>();
+    bool on = light.state["state"]["on"].get<bool>();
     if (cType == "ct")
     {
-        uint16_t oldCT = light.state["state"]["ct"];
+        uint16_t oldCT = light.state["state"]["ct"].get<uint16_t>();
         if (!light.setColorTemperature(mired, 1))
         {
             return false;
@@ -104,10 +104,10 @@ bool SimpleColorTemperatureStrategy::alertTemperature(unsigned int mired, HueLig
 unsigned int SimpleColorTemperatureStrategy::getColorTemperature(HueLight& light) const
 {
     light.refreshState();
-    return light.state["state"]["ct"];
+    return light.state["state"]["ct"].get<unsigned int>();
 }
 
 unsigned int SimpleColorTemperatureStrategy::getColorTemperature(const HueLight& light) const
 {
-    return light.state["state"]["ct"];
+    return light.state["state"]["ct"].get<unsigned int>();
 }

--- a/hueplusplus/test/test_HueLight.cpp
+++ b/hueplusplus/test/test_HueLight.cpp
@@ -385,9 +385,9 @@ TEST_F(HueLightTest, setName)
     HueLight test_light_2 = test_bridge.getLight(2);
     HueLight test_light_3 = test_bridge.getLight(3);
 
-    EXPECT_EQ(true, test_light_1.setName(expected_request["name"]));
-    EXPECT_EQ(false, test_light_2.setName(expected_request["name"]));
-    EXPECT_EQ(true, test_light_3.setName(expected_request["name"]));
+    EXPECT_EQ(true, test_light_1.setName(expected_request["name"].get<std::string>()));
+    EXPECT_EQ(false, test_light_2.setName(expected_request["name"].get<std::string>()));
+    EXPECT_EQ(true, test_light_3.setName(expected_request["name"].get<std::string>()));
 }
 
 TEST_F(HueLightTest, getColorType)


### PR DESCRIPTION
These are prone to breaking in the future or with some compiler versions, so it is better to remove them.

Closes #50 