### PR TITLE
Add new bulb types LCA003 and LCB001 to development branch

### DIFF
--- a/src/HueDeviceTypes.cpp
+++ b/src/HueDeviceTypes.cpp
@@ -47,7 +47,7 @@ const std::set<std::string>& getGamutBTypes()
 const std::set<std::string>& getGamutCTypes()
 {
     static const std::set<std::string> c_EXTENDEDCOLORLIGHT_GAMUTC_TYPES
-        = {"LCT010", "LCT011", "LCT012", "LCT014", "LCT015", "LCT016", "LLC020", "LST002"};
+        = {"LCT010", "LCT011", "LCT012", "LCT014", "LCT015", "LCT016", "LLC020", "LST002", "LCA003", "LCB001" };
     return c_EXTENDEDCOLORLIGHT_GAMUTC_TYPES;
 }
 


### PR DESCRIPTION
This addresses the missing bulb aspects of issue https://github.com/enwi/hueplusplus/issues/57

Adds support for these bulbs:

![20201102_171458](https://user-images.githubusercontent.com/1051772/97929594-249efe00-1d2f-11eb-8bab-bc2c2e4e52c9.jpg)

Tested using a Hue Bridge V1