### PR TITLE
Remove certificate parsing in Entertainment Mode

### DIFF
--- a/src/EntertainmentMode.cpp
+++ b/src/EntertainmentMode.cpp
@@ -122,12 +122,6 @@ EntertainmentMode::EntertainmentMode(Bridge& b, Group& g)
     | Seed the Deterministic Random Bit Generator (RNG) |
     \*-------------------------------------------------*/
     int ret = mbedtls_ctr_drbg_seed(&tls_context->ctr_drbg, mbedtls_entropy_func, &tls_context->entropy, NULL, 0);
-
-    /*-------------------------------------------------*\
-    | Parse certificate                                 |
-    \*-------------------------------------------------*/
-    ret = mbedtls_x509_crt_parse(
-        &tls_context->cacert, (const unsigned char*)mbedtls_test_cas_pem, mbedtls_test_cas_pem_len);
 }
 
 EntertainmentMode::~EntertainmentMode()


### PR DESCRIPTION
I finally got around to updating OpenRGB to pull in the latest version of hueplusplus and was working on getting it building on my GitLab CI under multiple Linux distributions.  The certificate parsing in mbedtls wasn't available in older distros, kept getting build errors from undefined symbols.  I took this section out of EntertainmentMode.cpp and tested it on multiple platforms and it does not appear to affect Philips Hue communication so I think it is safe to remove.  This way the library will build on more distributions.