### PR TITLE
Fix compatibility issues between MSYS2 and MSVC environments

### DIFF
--- a/examples/BridgeSetup.cpp
+++ b/examples/BridgeSetup.cpp
@@ -28,7 +28,7 @@
 
 #include <hueplusplus/Bridge.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <hueplusplus/WinHttpHandler.h>
 
 using SystemHttpHandler = hueplusplus::WinHttpHandler;

--- a/examples/LightsOff.cpp
+++ b/examples/LightsOff.cpp
@@ -26,7 +26,7 @@
 
 #include <hueplusplus/Bridge.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <hueplusplus/WinHttpHandler.h>
 
 using SystemHttpHandler = hueplusplus::WinHttpHandler;

--- a/examples/Snippets.cpp
+++ b/examples/Snippets.cpp
@@ -25,7 +25,7 @@
 #include <hueplusplus/CLIPSensors.h>
 #include <hueplusplus/ZLLSensors.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <hueplusplus/WinHttpHandler.h>
 
 namespace hueplusplus

--- a/examples/UsernameConfig.cpp
+++ b/examples/UsernameConfig.cpp
@@ -29,7 +29,7 @@
 
 #include <hueplusplus/Bridge.h>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <hueplusplus/WinHttpHandler.h>
 
 using SystemHttpHandler = hueplusplus::WinHttpHandler;

--- a/src/TimePattern.cpp
+++ b/src/TimePattern.cpp
@@ -90,7 +90,7 @@ system_clock::time_point parseTimestamp(const std::string& timestamp)
 std::chrono::system_clock::time_point parseUTCTimestamp(const std::string& timestamp)
 {
     std::tm tm = timestampToTm(timestamp);
-#ifdef _MSC_VER
+#ifdef _WIN32
     std::time_t ctime = _mkgmtime(&tm);
 #else
     // Non-standard, but POSIX compliant

--- a/src/WinHttpHandler.cpp
+++ b/src/WinHttpHandler.cpp
@@ -30,7 +30,9 @@
 #include <stdio.h>
 #include <ws2tcpip.h>
 
+#ifdef _MSC_VER
 #pragma comment(lib, "Ws2_32.lib")
+#endif
 
 namespace hueplusplus
 {


### PR DESCRIPTION
I noticed warnings about MSVC only features and changed the code a bit so it should work with other Windows build environments now.